### PR TITLE
added button for start and stop climate

### DIFF
--- a/custom_components/volvoaaos/__init__.py
+++ b/custom_components/volvoaaos/__init__.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform, CONF_USERNAME, CONF_ACCESS_TOKEN, CONF_PASSWORD
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.dt import now
 
@@ -15,7 +12,7 @@ from .const import DOMAIN, LOGGER, CONF_VCC_API_KEY, CONF_VIN, CONF_REFRESH_TOKE
 from .volvo import Auth, Energy, ConnectedVehicle, Location
 from .coordinator import VolvoUpdateCoordinator, VolvoData
 
-PLATFORMS = [Platform.SENSOR, Platform.LOCK, Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
+PLATFORMS = [Platform.SENSOR, Platform.LOCK, Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER, Platform.BUTTON]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -72,13 +69,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    async def start_climatization(call: ServiceCall) -> None:
-        """Service call to start climatization"""
-        await connected_vehicle.set_climate_start()
-
-    hass.services.async_register(DOMAIN, SERVICE_START_CLIMATIZATION, start_climatization)
-
 
     return True
 

--- a/custom_components/volvoaaos/button.py
+++ b/custom_components/volvoaaos/button.py
@@ -1,0 +1,78 @@
+"""Support for Volvo AAOS binary sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Awaitable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, LOGGER
+
+from .coordinator import VolvoData, VolvoUpdateCoordinator
+
+from .entity import VolvoEntity
+from .volvo import ConnectedVehicle
+
+@dataclass
+class VolvoButtonEntityMixin:
+    """Mixin values for Volvo binary sensor entities."""
+
+    button_fn: Callable[[ConnectedVehicle], Awaitable[Any]]
+
+@dataclass
+class VolvoButtonEntityDescription(ButtonEntityDescription, VolvoButtonEntityMixin):
+    """Class describing Volvo AAOS binary sensor entities"""
+
+BUTTONS = [
+    VolvoButtonEntityDescription(
+        key="start_cliamte",
+        name="Start climate",
+        button_fn=lambda client: client.set_climate_start(),
+    ),
+    VolvoButtonEntityDescription(
+        key="stop_cliamte",
+        name="Stop climate",
+        button_fn=lambda client: client.set_climate_stop(),
+    ),
+
+]
+
+async def async_setup_entry(
+        hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Setup Volvo binary sensors from config entry."""
+
+    volvo_coordinator: VolvoUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        VolvoButtonEntity(
+            coordinator=volvo_coordinator,
+            description=description
+        )
+        for description in BUTTONS
+    )
+
+class VolvoButtonEntity(VolvoEntity,ButtonEntity):
+    """Representation of a Volvo binary sensor."""
+
+    entity_description: VolvoButtonEntityDescription
+
+    def __init__(self, coordinator: VolvoUpdateCoordinator, description: VolvoButtonEntityDescription) -> None:
+        """Initiate Volvo binary sensor."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_unique_id = f"{description.key}"
+
+    async def async_press(self) -> None:
+        self.coordinator.set_tokens()
+        await self.entity_description.button_fn(self.coordinator.connected_vehicle)

--- a/custom_components/volvoaaos/climate.py
+++ b/custom_components/volvoaaos/climate.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.climate import(
     ClimateEntity,
@@ -20,5 +21,13 @@ from .const import DOMAIN, LOGGER
 from .coordinator import VolvoData, VolvoUpdateCoordinator
 
 from .entity import VolvoEntity
+from .volvo import ConnectedVehicle
+
+@dataclass
+class VolvoClimateEntityMixin:
+    """Mixin values for Volvo climate entities."""
+    value_fn: Callable[[VolvoData], float]
+    lock_fn: Callable[[ConnectedVehicle], Awaitable[Any]]
+    unlock_fn: Callable[[ConnectedVehicle], Awaitable[Any]]
 
 

--- a/custom_components/volvoaaos/manifest.json
+++ b/custom_components/volvoaaos/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pydantic>=1.10"
   ],
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/custom_components/volvoaaos/models.py
+++ b/custom_components/volvoaaos/models.py
@@ -243,6 +243,20 @@ class StartClimateModel(BaseModel):
     operation_id: str = Field(..., alias='operationId')
     data: StartClimateData
 
+
+class StopClimateData(BaseModel):
+    vin: str
+    statusCode: int
+    invokeStatus: str
+    message: str
+
+
+class StopClimateModel(BaseModel):
+    status: int
+    operationId: str
+    data: StopClimateData
+
+
 class LockData(BaseModel):
     vin: str
     statusCode: int

--- a/custom_components/volvoaaos/volvo.py
+++ b/custom_components/volvoaaos/volvo.py
@@ -11,7 +11,7 @@ import async_timeout
 from aiohttp.client import ClientSession
 from aiohttp.hdrs import METH_GET, METH_POST
 
-from .models import AuthModel, RechargeModel, GetVinModel, GetVehicleModel, GetDoorModel, StartClimateModel, LockModel, UnlockModel, GetWindowModel, LocationModel
+from .models import AuthModel, RechargeModel, GetVinModel, GetVehicleModel, GetDoorModel, StartClimateModel, StopClimateModel, LockModel, UnlockModel, GetWindowModel, LocationModel
 from .const import LOGGER
 
 
@@ -238,6 +238,20 @@ class ConnectedVehicle(Volvo):
 
         response = await self._request(url=url, headers=headers, method=METH_POST)
         return StartClimateModel.parse_obj(response)
+
+    async def  set_climate_stop(self):
+        """Stop climatization"""
+
+        url = f"https://api.volvocars.com/connected-vehicle/v2/vehicles/{self.vin}/commands/climatization-stop"
+
+        headers = {
+            "content-type": self.content_type,
+            "authorization": f"Bearer {self.access_token}",
+            "vcc-api-key": self.vcc_api_key,
+        }
+
+        response = await self._request(url=url, headers=headers, method=METH_POST)
+        return StopClimateModel.parse_obj(response)
 
 
 class Location(Volvo):


### PR DESCRIPTION
Can not find a API endpoint to show if climate is on or off, so Home Assistant can not keep track, therefore climate is controlled using buttons.
BUT there is hope! If climate is started from Home Assistant it quickly changes in the iPhone app, so if someone finds this endpoint it should be easy to convert to a climate entity,